### PR TITLE
fix: removing snyk file that is not valid for java

### DIFF
--- a/todolist-web-struts/.snyk
+++ b/todolist-web-struts/.snyk
@@ -1,8 +1,0 @@
-
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.7.1
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
-patch:
-  'SNYK-JAVA-ORGAPACHESTRUTS-30207':
-      patch: 'struts2-core-2.3.20.jar'


### PR DESCRIPTION
Snyk file contains bad policy, that we don't support