### PR TITLE
fix: use vulnerable zt library

### DIFF
--- a/todolist-web-struts/pom.xml
+++ b/todolist-web-struts/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-zip</artifactId>
-            <version>1.13</version>
+            <version>1.12</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The current pom file has the fixed version of the zeroturnaround library so the zip-slip exploit poc isn't showing up well :-)

/cc @bmvermeer