### PR TITLE
Add `spring-context` artifactId as dependency so it still builds after Snyk fixing vulns

### DIFF
--- a/todolist-core/pom.xml
+++ b/todolist-core/pom.xml
@@ -17,6 +17,12 @@
         <!--spring-->
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
             <version>${spring.version}</version>
         </dependency>


### PR DESCRIPTION
Without this, if I fixed the fixable vulnerabilities with Snyk, the project would not build. I tracked it down to specifically the bump of the spring.version from `3.2.6.RELEASE` to `3.2.15.RELEASE` (which is what the Snyk fix PR does, among two other dep version changes). Seems like we need to add the `spring-context` artifact (groupId `org.springframework`) in order for `org.springframework.stereotype` to be resolved with the newer version.