### PR TITLE
Update war plugin to be compatible with OpenJDK 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.iml
 .idea
 */target/**
+**/.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   javagoof:
-    build: .
+    image: javagoof:orig
     container_name: javagoof
     environment:
       - DOCKER=1

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.2.3</version>
                     <configuration>
                         <warName>todolist</warName>
                     </configuration>


### PR DESCRIPTION
mvn package fails on OpenJDK 16 with the older version of the maven war plugin