### PR TITLE
Update pom.xml for todolist

### DIFF
--- a/todolist-goof/pom.xml
+++ b/todolist-goof/pom.xml
@@ -58,8 +58,8 @@
                     <version>3.2</version>
                     <configuration>
                         <verbose>true</verbose>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <showWarnings>true</showWarnings>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
New installs of maven fail to build this project which causes the Snyk CLI to fail. This appears to be due to a compatibility issue with more recent versions of Maven. When running 'Snyk code test --all-projects' from a terminal you get the below:

[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Java Goof 0.0.1-SNAPSHOT:
[INFO] 
[INFO] Java Goof :: TodoList Goof ......................... SUCCESS [  0.093 s]
[INFO] Java Goof :: Todolist Goof :: Todolist Core ........ FAILURE [  0.496 s]
[INFO] Java Goof :: Todolist Goof :: Todolist Web Common .. SKIPPED
[INFO] Java Goof :: Todolist Goof :: Todolist Web Struts .. SKIPPED
[INFO] Java Goof :: Log4Shell Goof :: Log4Shell Server .... SKIPPED
[INFO] Java Goof :: Log4Shell Goof ........................ SKIPPED
[INFO] Java Goof :: Log4Shell Goof :: Log4Shell Client .... SKIPPED
[INFO] Java Goof .......................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.652 s
[INFO] Finished at: 2023-10-11T13:56:44-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.2:compile (default-compile) on project todolist-core: Compilation failure: Compilation failure: 
[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.

Bumping the values in the pom.xml to 1.8 seems to resolve this.