### PR TITLE
Upgrade compiler source for todolist-goof

### DIFF
--- a/todolist-goof/pom.xml
+++ b/todolist-goof/pom.xml
@@ -58,8 +58,8 @@
                     <version>3.2</version>
                     <configuration>
                         <verbose>true</verbose>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <showWarnings>true</showWarnings>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
The project was no longer building because of `<artifactId>maven-compiler-plugin</artifactId>` had been using JDK 1.7 and now the code requires features from JDK 1.8.

The change now builds successfully.