### PR TITLE
log4j-core vulnerability fix in git

### DIFF
--- a/log4shell-goof/log4shell-client/pom.xml
+++ b/log4shell-goof/log4shell-client/pom.xml
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.14.1</version>
+      <version>2.25.4</version>
     </dependency>
   </dependencies>
 

--- a/log4shell-goof/log4shell-server/pom.xml
+++ b/log4shell-goof/log4shell-server/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>com.unboundid</groupId>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a large Log4j version jump (2.14/2.15 to 2.25.4) that could introduce runtime/config behavior changes, though the change is isolated to Maven dependency versions.
> 
> **Overview**
> Updates `log4shell-client` and `log4shell-server` Maven dependencies to use **Log4j 2.25.4** (bumping `log4j-core` in both modules and `log4j-api` in the client) to address known Log4j vulnerabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8461fee3ed0ba5d6da7d9a5943840246f4f4dbc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->